### PR TITLE
Fix build bdk-ffi for aarch64-apple-ios-sim

### DIFF
--- a/.github/workflows/publish-spm.yaml
+++ b/.github/workflows/publish-spm.yaml
@@ -60,13 +60,13 @@ jobs:
       - name: Build bdk-ffi for aarch64-apple-ios-sim
         working-directory: build
         run: |
-          cargo +nightly-2023-04-10 build --release --target aarch64-apple-ios-sim
+          cargo +nightly-2023-04-10 build --profile release-smaller --target aarch64-apple-ios-sim
 
       - name: Create lipo-ios-sim and lipo-macos
         working-directory: build
         run: |
           mkdir -p target/lipo-ios-sim/release-smaller
-          lipo target/aarch64-apple-ios-sim/release/libbdkffi.a target/x86_64-apple-ios/release-smaller/libbdkffi.a -create -output target/lipo-ios-sim/release-smaller/libbdkffi.a
+          lipo target/aarch64-apple-ios-sim/release-smaller/libbdkffi.a target/x86_64-apple-ios/release-smaller/libbdkffi.a -create -output target/lipo-ios-sim/release-smaller/libbdkffi.a
           mkdir -p target/lipo-macos/release-smaller
           lipo target/aarch64-apple-darwin/release-smaller/libbdkffi.a target/x86_64-apple-darwin/release-smaller/libbdkffi.a -create -output target/lipo-macos/release-smaller/libbdkffi.a
 

--- a/.github/workflows/publish-spm.yaml
+++ b/.github/workflows/publish-spm.yaml
@@ -27,10 +27,10 @@ jobs:
       - name: Install Rust targets
         working-directory: build
         run: |
-          rustup install nightly-x86_64-apple-darwin
-          rustup component add rust-src --toolchain nightly-x86_64-apple-darwin
+          rustup install nightly-2023-04-10
+          rustup component add rust-src --toolchain nightly-2023-04-10
           rustup target add aarch64-apple-ios x86_64-apple-ios
-          rustup target add aarch64-apple-ios-sim --toolchain nightly
+          rustup target add aarch64-apple-ios-sim --toolchain nightly-2023-04-10
           rustup target add aarch64-apple-darwin x86_64-apple-darwin
 
       - name: Run bdk-ffi-bindgen
@@ -60,7 +60,7 @@ jobs:
       - name: Build bdk-ffi for aarch64-apple-ios-sim
         working-directory: build
         run: |
-          cargo +nightly build --release -Z build-std --target aarch64-apple-ios-sim
+          cargo +nightly-2023-04-10 build --release --target aarch64-apple-ios-sim
 
       - name: Create lipo-ios-sim and lipo-macos
         working-directory: build


### PR DESCRIPTION
The build-publish job is failing due to changes to the rustc `nightly` version, which breaks the `miniscript` build, see rust-bitcoin/rust-miniscript#541. I removed the `-Z build-std` part of the build step (it isn't needed anymore to build for the  [aarch64-apple-ios-sim](https://doc.rust-lang.org/nightly/rustc/platform-support.html) target), ~~this seems to fix the error for now~~ .. ~~nevermind it's still not working.~~, I also had to change the nightly version to an older version, I chose `nightly-2023-04-10` and that one works.