### PR TITLE
Use Rust compiler 1.77.1

### DIFF
--- a/.github/workflows/publish-spm.yaml
+++ b/.github/workflows/publish-spm.yaml
@@ -31,7 +31,7 @@ jobs:
       - name: "Install Rust targets"
         working-directory: build/bdk-ffi
         run: |
-          rustup install 1.73.0
+          rustup default 1.77.1
           rustup component add rust-src
           rustup target add aarch64-apple-ios      # iOS ARM64
           rustup target add x86_64-apple-ios       # iOS x86_64


### PR DESCRIPTION
This is required to bring the build in line with the other libraries for the release of the alpha 9 version.