### PR TITLE
chore: update publish-spm.yaml to use xcodebuild tool

### DIFF
--- a/.github/workflows/publish-spm.yaml
+++ b/.github/workflows/publish-spm.yaml
@@ -28,51 +28,12 @@ jobs:
         with:
           path: dist
 
-      - name: "Install Rust targets"
-        working-directory: build/bdk-ffi
-        run: |
-          rustup default 1.77.1
-          rustup component add rust-src
-          rustup target add aarch64-apple-ios      # iOS ARM64
-          rustup target add x86_64-apple-ios       # iOS x86_64
-          rustup target add aarch64-apple-ios-sim  # simulator mac M1
-          rustup target add aarch64-apple-darwin   # mac M1
-          rustup target add x86_64-apple-darwin    # mac x86_64
-
-      - name: "Run bdk-ffi-bindgen"
-        working-directory: build/bdk-ffi
-        run: |
-          cargo run --bin uniffi-bindgen generate src/bdk.udl --language swift --out-dir ../bdk-swift/Sources/BitcoinDevKit --no-format
-      
-      - name: "Build bdk-ffi for all targets"
-        working-directory: build/bdk-ffi
-        run: |
-          cargo build --profile release-smaller --target x86_64-apple-darwin
-          cargo build --profile release-smaller --target aarch64-apple-darwin
-          cargo build --profile release-smaller --target x86_64-apple-ios
-          cargo build --profile release-smaller --target aarch64-apple-ios
-          cargo build --profile release-smaller --target aarch64-apple-ios-sim
-
-      - name: "Create lipo-ios-sim and lipo-macos"
-        working-directory: build/bdk-ffi
-        run: |
-          mkdir -p target/lipo-ios-sim/release-smaller
-          lipo target/aarch64-apple-ios-sim/release-smaller/libbdkffi.a target/x86_64-apple-ios/release-smaller/libbdkffi.a -create -output target/lipo-ios-sim/release-smaller/libbdkffi.a
-          mkdir -p target/lipo-macos/release-smaller
-          lipo target/aarch64-apple-darwin/release-smaller/libbdkffi.a target/x86_64-apple-darwin/release-smaller/libbdkffi.a -create -output target/lipo-macos/release-smaller/libbdkffi.a
-
       - name: "Create bdkFFI.xcframework"
         working-directory: build/bdk-swift
         run: |
-          mv Sources/BitcoinDevKit/bdk.swift Sources/BitcoinDevKit/BitcoinDevKit.swift
-          cp Sources/BitcoinDevKit/bdkFFI.h bdkFFI.xcframework/ios-arm64/bdkFFI.framework/Headers
-          cp Sources/BitcoinDevKit/bdkFFI.h bdkFFI.xcframework/ios-arm64_x86_64-simulator/bdkFFI.framework/Headers
-          cp Sources/BitcoinDevKit/bdkFFI.h bdkFFI.xcframework/macos-arm64_x86_64/bdkFFI.framework/Headers
-          cp ../bdk-ffi/target/aarch64-apple-ios/release-smaller/libbdkffi.a bdkFFI.xcframework/ios-arm64/bdkFFI.framework/bdkFFI
-          cp ../bdk-ffi/target/lipo-ios-sim/release-smaller/libbdkffi.a bdkFFI.xcframework/ios-arm64_x86_64-simulator/bdkFFI.framework/bdkFFI
-          cp ../bdk-ffi/target/lipo-macos/release-smaller/libbdkffi.a bdkFFI.xcframework/macos-arm64_x86_64/bdkFFI.framework/bdkFFI
-          rm Sources/BitcoinDevKit/bdkFFI.h
-          rm Sources/BitcoinDevkit/bdkFFI.modulemap
+          # run the local script
+          ./build-xcframework.sh
+          # remove old xcframework zip
           rm bdkFFI.xcframework.zip || true
           zip -9 -r bdkFFI.xcframework.zip bdkFFI.xcframework
           echo "BDKFFICHECKSUM=`swift package compute-checksum bdkFFI.xcframework.zip`" >> $GITHUB_ENV

--- a/.github/workflows/publish-spm.yaml
+++ b/.github/workflows/publish-spm.yaml
@@ -17,14 +17,14 @@ jobs:
     runs-on: macos-12
     steps:
       - name: "Checkout build repo"
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: ${{ github.repository_owner }}/bdk-ffi
           path: build
           ref: ${{ inputs.ffitag }}
 
       - name: "Checkout dist repo"
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           path: dist
 


### PR DESCRIPTION
This PR should match the changes made in https://github.com/bitcoindevkit/bdk-ffi/pull/557.