### PR TITLE
ci: use macos-14 image in ci

### DIFF
--- a/.github/workflows/publish-spm.yaml
+++ b/.github/workflows/publish-spm.yaml
@@ -14,7 +14,7 @@ on:
 jobs:
   build-publish:
     name: Build, tag and create release
-    runs-on: macos-12
+    runs-on: macos-14
     steps:
       - name: "Checkout build repo"
         uses: actions/checkout@v4


### PR DESCRIPTION
mirrors https://github.com/bitcoindevkit/bdk-ffi/pull/634

The [release action](https://github.com/bitcoindevkit/bdk-swift/actions/runs/12400061672/job/34616353704) failed because the macos-12 image is deprecated. This bumps it to macos-14.

<img width="1496" alt="Screenshot 2024-12-18 at 1 48 24 PM" src="https://github.com/user-attachments/assets/2ea6d5bd-7e58-4d56-9172-02b9e423d745" />

