### PR TITLE
Use macos-13 image for pre-1.0 builds

### DIFF
--- a/.github/workflows/publish-spm.yaml
+++ b/.github/workflows/publish-spm.yaml
@@ -10,7 +10,7 @@ on:
 jobs:
   build-publish:
     name: Build, tag and create release
-    runs-on: macos-12
+    runs-on: macos-13
     steps:
       - name: Checkout build repo
         uses: actions/checkout@v3


### PR DESCRIPTION
The [pre-1.0-workflow](https://github.com/bitcoindevkit/bdk-swift/tree/pre-1.0-workflow) branch uses the `macos-12` image, which is not available anymore. This bumps it to `macos-13`.