### PR TITLE
Remove bitcoin-ffi source code from publishing job

### DIFF
--- a/.github/workflows/publish-spm.yaml
+++ b/.github/workflows/publish-spm.yaml
@@ -46,10 +46,8 @@ jobs:
           echo url = ${{ env.BDKFFIURL }}
           sed "s/BDKFFICHECKSUM/${BDKFFICHECKSUM}/;s/BDKFFIURL/${BDKFFIURL}/" Package.swift.txt > ../../dist/Package.swift
           cp Sources/BitcoinDevKit/BitcoinDevKit.swift ../../dist/Sources/BitcoinDevKit/BitcoinDevKit.swift
-          cp Sources/BitcoinDevKit/Bitcoin.swift ../../dist/Sources/BitcoinDevKit/Bitcoin.swift
           cd ../../dist
           git add Sources/BitcoinDevKit/BitcoinDevKit.swift
-          git add Sources/BitcoinDevKit/Bitcoin.swift
           git add Package.swift
           git commit -m "Update BitcoinDevKit.swift and Package.swift for release ${{ inputs.version }}"
           git push


### PR DESCRIPTION
This fixes the [error we are getting when attempting to publish 1.1.0-rc.1](https://github.com/bitcoindevkit/bdk-swift/actions/runs/13549796666/job/37870373732).

We do not depend on bitcoin-ffi anymore, and therefore don't produce a source file for those types anymore either. They have been removed from the [build script here](https://github.com/bitcoindevkit/bdk-ffi/commit/85c650caac259a111641d521b63394dcdc06bffc#diff-071697d8b5fed6f94db5593b4cd2535514735493e6d842ba56a8f10e0a73e9cf).